### PR TITLE
Improve error handling and parallelise

### DIFF
--- a/R/detect_anomalies.R
+++ b/R/detect_anomalies.R
@@ -36,27 +36,26 @@ detect_anomalies <- function(
                           quantity = quantity,
                           fill_missing = 0,
                           freq = freq),
-                          error = function(e){
-                           message(paste("Skipping code", codes[i], "- error in detect_date_frequency:", e$message))
-                           return(NULL)})
-    message(paste("Output: ", codes[i], class(ts_data)))
-    #print(ts_data)
-   #if(inherits(ts_data, "try-error")){message(paste("Skipping code", codes[i]))
-    #               next}
-   if (is.null(ts_data)){next}
+                          error = function(e) e)
+
+    if(inherits(ts_data, "error")){
+      message(paste("Skipping code", codes[i], ":", ts_data))
+      next
+    }
 
     selected_model <- tryCatch(select_best_model(data = ts_data,
                                         response_col = quantity,
                                         date_col = date_col,
                                         metric = model_selection_metric,
                                         scale_ts = scale_ts),
-                               error = function(e){
-                                       message(paste("Skipping code", codes[i], "- detect_date_frequency error:", e$message))
-                                       return(NULL)})
-    message(paste("Output: ", codes[i], selected_model$formula))
-    if (is.null(selected_model)) next
+                               error = function(e) e)
 
-    detect_anomaly <- try(
+    if(inherits(selected_model, "error")){
+      message(paste("Skipping code", codes[i], ":", selected_model))
+      next
+    }
+
+    detect_anomaly <- tryCatch(
       tso(
         y = if(scale_ts){
           as.ts(scale(ts_data[[quantity]]))
@@ -67,10 +66,10 @@ detect_anomalies <- function(
           selected_model$xreg
         } else {NULL},
         ...),
-      silent=T)
-    message(paste("Output: ", codes[i], class(detect_anomaly)))
-    if ("try-error" %in% class(detect_anomaly)){
-      message("Anomaly detection failed for code: ", codes[i])
+      error = function(e) e)
+
+    if(inherits(detect_anomaly, "error")){
+      message(paste("Skipping code", codes[i], ":", detect_anomaly))
       next
     }
 

--- a/R/detect_anomalies.R
+++ b/R/detect_anomalies.R
@@ -29,9 +29,10 @@ detect_anomalies <- function(
   all_outliers <- list()
   tso_output <- list()
 
+  ts_prep <- list()
   for (i in seq_along(codes)){
 
-    ts_data <- tryCatch(extract_ts(import_data,
+    ts_prep[[i]] <- tryCatch(extract_ts(import_data,
                           code = codes[i],
                           date_col = date_col,
                           quantity = quantity,
@@ -39,10 +40,13 @@ detect_anomalies <- function(
                           freq = freq),
                           error = function(e) e)
 
-    if(inherits(ts_data, "error")){
-      message(paste("Skipping code", codes[i], ":", ts_data))
+    if(inherits(ts_prep, "error")){
+      message(paste("Skipping code", code, ":", ts_prep))
       next
     }
+  }
+
+  process_ts <- function(ts_data, code) {
 
     selected_model <- tryCatch(select_best_model(data = ts_data,
                                         response_col = quantity,
@@ -52,8 +56,8 @@ detect_anomalies <- function(
                                error = function(e) e)
 
     if(inherits(selected_model, "error")){
-      message(paste("Skipping code", codes[i], ":", selected_model))
-      next
+      message(paste("Skipping code", code, ":", selected_model))
+      return(NULL)
     }
 
     detect_anomaly <- tryCatch(
@@ -70,31 +74,41 @@ detect_anomalies <- function(
       error = function(e) e)
 
     if(inherits(detect_anomaly, "error")){
-      message(paste("Skipping code", codes[i], ":", detect_anomaly))
-      next
+      message(paste("Skipping code", code, ":", detect_anomaly))
+      return(NULL)
     }
 
     #storing all tso output
-    tso_output[[codes[i]]] <- list(tso=detect_anomaly,
-                                y=if(scale_ts){as.ts(scale(ts_data[[quantity]]))} else{as.ts(ts_data[[quantity]])},
-                                time_index=ts_data[[date_col]])
+    tso_entry <- setNames(
+      list(list(tso=detect_anomaly,
+                y=if(scale_ts){as.ts(scale(ts_data[[quantity]]))} else{as.ts(ts_data[[quantity]])},
+                time_index=ts_data[[date_col]])),
+      code
+    )
 
     if (nrow(detect_anomaly$outliers)>0){
 
       #store outliers data produced
       new_outliers <- as.data.table(detect_anomaly$outliers)
-      new_outliers[, code := codes[i]]
+      new_outliers[, code := code]
       new_outliers[, model_formula := paste(deparse(selected_model$formula), collapse = " ")]
 
       new_outliers[, time := ts_data$DATE_START[ind]]
 
-      all_outliers[[i]] <- new_outliers
+      outliers_entry <- new_outliers
     } else {
-      all_outliers[[i]] <- data.table(code = codes[i],
-                                      model_formula = deparse(selected_model$formula))
+      outliers_entry <- data.table(code = code,
+                                   model_formula = deparse(selected_model$formula))
     }
 
+    list(outliers = outliers_entry, tso = tso_entry)
   }
+
+  results <- future.apply::future_mapply(process_ts, ts_prep, codes, SIMPLIFY = FALSE)
+  results <- Filter(Negate(is.null), results)
+
+  all_outliers <- lapply(results, `[[`, "outliers")
+  tso_output <- do.call(c, lapply(results, `[[`, "tso"))
 
   return(list(outliers=rbindlist(all_outliers, fill = TRUE),
          tso_output=tso_output))

--- a/R/utils.R
+++ b/R/utils.R
@@ -2,7 +2,7 @@
 #'
 #' This function detects the frequency of a time series.
 #'
-#' @param dates A vector of dates or name of column containing timestamps.
+#' @param dates A vector of dates
 #'
 #' @return A character string indicating the detected date frequency: "day", "week", or "month".
 #'
@@ -10,9 +10,7 @@
 detect_date_frequency <- function(dates) {
 
   if (! inherits(dates, "Date") ) {
-     tryCatch(
-     dates <- as.Date(dates),
-      stop("Input not of class \"Date\" and couldn't be converted."))
+     dates <- as.Date(dates)
   }
 
   # Remove duplicates and sort
@@ -87,22 +85,8 @@ extract_ts <- function (import_data,
     setnames(ts_data,"agg",quantity)
   }
 
- if (is.null(freq)) {
- freq <- detect_date_frequency(ts_data[[date_col]])
-#  if (is.null(freq)) {
-#    freq <- tryCatch(
-#      detect_date_frequency(ts_data[, get(date_col)]),
- #     error = function(e) {
- #       message(paste("Code", code, "-", e$message))
- #       return(NULL)
-#      }
-#    )
-
- #   if (is.null(freq)) {
- #     return(NULL)
- #   }
-
-
+  if (is.null(freq)) {
+    freq <- detect_date_frequency(ts_data[[date_col]])
   } else {
     if( !freq %in% c("day","week","month")) {
       stop("\"freq\" must be \"day\",\"week\" or \"month\"")

--- a/docs/UserGuide.qmd
+++ b/docs/UserGuide.qmd
@@ -285,8 +285,9 @@ hs2_anomalies_volume <- detect_anomalies(import_data = imports_ipaffs,
                                   cval=5,
                                   types = c("AO", "LS", "TC", "IO"),
                                   freq = "day")
-head(hs2_anomalies_netmass)
-head(hs2_anomalies_volume)
+
+head(hs2_anomalies_netmass$outliers)
+head(hs2_anomalies_volume$outliers)
 
 ```
 

--- a/docs/UserGuide.qmd
+++ b/docs/UserGuide.qmd
@@ -234,11 +234,11 @@ plot(ts_data)
 The anomaly detection procedure described using the monthly HMRC data can also be applied to the daily IPAFFS data. This involves using the same functions, such as, `extract_ts` to obtain the time series of a given commodity code, `select_best_model` to select an appropriate model from a set of candidate models and using the outlier detection algorithm to identify the various types of outliers.
 
 ```{r}
-#| eval: false
+#| eval: true
 #| warning: false
 
 ts_data <- extract_ts(imports_ipaffs[DATE_START>="2023-01-01"],
-                      code = "06",
+                      code = "07",
                       quantity = "NET_MASS",
                       date_col = "DATE_START",
                       fill_missing=0)
@@ -268,7 +268,7 @@ Here is also an example of using the `detect_anomalies()` function to a selected
 
 hs2_codes <- sort(unique(substr(imports_ipaffs$COMCODE, 1,2)))
 
-hs2_anomalies_netmass <- detect_anomalies(import_data = imports_ipaffs[DATE_START>="2022-01-01"],
+hs2_anomalies_netmass <- detect_anomalies(import_data = imports_ipaffs[DATE_START>="2023-01-01"],
                                   codes = hs2_codes[1:6],
                                   quantity = "NET_MASS",
                                   scale=T,


### PR DESCRIPTION
Hi @janeetam,

I've adjusted the error handling here to make it a bit more robust and readable. I hope it makes sense. I've been able to run the useguide to test and it behaves as intended. I also removed some of the "message" calls as I assume these were just added for testing. However, it might be good to have a "verbose" option, or progress bar if this function is going to take a long time to run.

I also had a look at switching the for loop to `future.lapply` however a simple switch results in an attempt to send `import_data` to all parallel workers, which was too much data. However, I think if time series for all codes are generated first, I think this can be avoided... I'll work on this next.