### PR TITLE
Suggested pattern for detect_anomalies with tsibble.

### DIFF
--- a/R/detect_anomalies.R
+++ b/R/detect_anomalies.R
@@ -60,28 +60,39 @@ detect_anomalies <- function(
   all_outliers <- lapply(results, `[[`, "outliers")
   list_of_ts <- lapply(results, `[[`, "list_of_ts")
   names(list_of_ts) <- lapply(results, `[[`, "id")
+  all_formulas <- lapply(results, `[[`, "formula")
+  names(all_formulas) <- lapply(results, `[[`, "id")
   return(list(
     outliers = rbindlist(all_outliers, fill = TRUE),
-    list_of_ts = list_of_ts
+    list_of_ts = list_of_ts,
+    formulas = all_formulas
   ))
 }
 
 #' Detect anomalies in a single time series (Internal)
 #' @note This needs to return a list of time series with original tsibble attributes. See suggested pattern in comments...
 #'
-.detect_anomalies_single_ts <- function(
+detect_anomalies_single_ts <- function(
   ts_data,
   id,
   response_col,
   date_col,
   scale_ts
 ) {
-
-  if ( inherits(ts_data,"tsibble") ) {
+  if (inherits(ts_data, "tsibble")) {
     # Store attributes & convert to data.table...
-    #
-    # .tsibble_attributes <- attr(ts_data)
-    # ts_data <- data.table::as.data.table(ts_data)
+    tsibble_attributes <- data %>% group_by_key() %>% group_keys()
+    key_names <- names(tsibble_attributes)
+    ts_data_split <- data %>% group_by_key() %>% group_split()
+    ts_data_split <- lapply(ts_data_split, function(x) {
+      dt <- as.data.table(x[, c("DATE_START", "NET_MASS")])
+      dt[, DATE_START := as.Date(DATE_START)]
+      dt
+    })
+    ts_data <- ts_data_split
+
+    # note: tsibble_attributes <- attr(ts_data)
+    # note: ts_data <- data.table::as.data.table(ts_data)
   }
 
   sparse_rate <- mean(ts_data[[response_col]] == 0, na.rm = T)
@@ -101,7 +112,7 @@ detect_anomalies <- function(
   if (verbose) {
     message(sprintf("Running selected_model for %s", id))
   }
-
+  # model selection
   selected_model <- tryCatch(
     select_best_model(
       data = ts_data,
@@ -123,6 +134,7 @@ detect_anomalies <- function(
     message(sprintf("Running detect_anomaly for %s", id))
   }
 
+  # matrix of regressors
   ts_data <- selected_model$data
   break_entry <- selected_model$break_entry
   xreg_all <- model.matrix(selected_model$formula, data = ts_data)
@@ -132,6 +144,7 @@ detect_anomalies <- function(
     xreg_all <- NULL
   }
 
+  # tso outlier detection
   outliers <- detect_outliers(
     data = ts_data,
     quantity = response_col, ### Change quantity to response_col!!!
@@ -142,13 +155,24 @@ detect_anomalies <- function(
 
   ts_data <- outliers$data
 
+  # update formula
+  tso_vars <- grep("^(AO|TC|IO)", names(ts_data), value = TRUE)
+  if (length(tso_vars) > 0) {
+    updated_formula <- update(
+      selected_model$formula,
+      paste(". ~ . +", paste(tso_vars, collapse = " + "))
+    )
+  } else {
+    updated_formula <- selected_model$formula
+  }
+
   if (!is.null(outliers$outliers) && nrow(outliers$outliers) > 0) {
-    #store tso outliers data produced
+    # store tso outliers data produced
     new_outliers <- as.data.table(outliers$outliers)
     new_outliers[, id := id]
-    new_outliers[,
-      model_formula := paste(deparse(selected_model$formula), collapse = " ")
-    ]
+    # new_outliers[,
+    #   model_formula := paste(deparse(selected_model$formula), collapse = " ")
+    # ]
 
     new_outliers[, time := ts_data$DATE_START[ind]]
     new_outliers[, anomaly_type := "Outlier"]
@@ -161,9 +185,9 @@ detect_anomalies <- function(
   #add breaks table
   if (!is.null(break_entry) && nrow(break_entry) > 0) {
     break_entry[, id := id]
-    break_entry[,
-      model_formula := paste(deparse(selected_model$formula), collapse = " ")
-    ]
+    # break_entry[,
+    #   model_formula := paste(deparse(selected_model$formula), collapse = " ")
+    # ]
     break_entry[, anomaly_type := "Break"]
 
     outliers_entry <- rbindlist(
@@ -176,23 +200,36 @@ detect_anomalies <- function(
     break_entry <- data.table()
   }
 
-  #no break no outlier option
+  # no break no outlier option
   if (nrow(outliers_entry) == 0) {
     outliers_entry <- data.table(
       id = id,
-      model_formula = paste(deparse(selected_model$formula), collapse = " "),
+      # model_formula = paste(deparse(selected_model$formula), collapse = " "),
       anomaly_type = "None"
     )
   }
 
-  if ( inherits(ts_data,"tsibble") ) {
-    # Covert back to tsibble and assign attributes...
-    #
-    # ts_data <- fable::as.tsibble(ts_data)
-    # attr(ts_data) <- .tsibble_attributes
+  # back to tsibble if tsibble
+  if (inherits(ts_data, "tsibble")) {
+    # option 1 without keys
+    ts_data$hierarchy_id <- id
+    ts_data[, (key_names) := tstrsplit(hierarchy_id, "\\|")]
+    all_ts <- ts_data[!is.na(DATE_START)][, DATE_START := yearmonth(DATE_START)]
+    all_ts <- as_tsibble(all_ts, key = key_names, index = DATE_START)
+    # function to return `all_ts` with attributes as tsibble format
 
+    #option 2 with keys
+
+    # note: Covert back to tsibble and assign attributes...
+    # note: ts_data <- fable::as.tsibble(ts_data)
+    # note: attr(ts_data) <- .tsibble_attributes
   }
 
   p(sprintf("Completed time series %s", id))
-  return(list(outliers = outliers_entry, list_of_ts = ts_data, id = id))
+  return(list(
+    outliers = outliers_entry,
+    list_of_ts = ts_data,
+    formula = updated_formula,
+    id = id
+  ))
 }

--- a/R/detect_anomalies.R
+++ b/R/detect_anomalies.R
@@ -25,9 +25,8 @@
 #'
 #' @export
 detect_anomalies <- function(
-  import_data,
-  codes,
-  quantity = "NET_MASS",
+  data,
+  response_col = "NET_MASS",
   date_col = "DATE_START",
   model_selection_metric = AIC,
   scale_ts = FALSE,
@@ -35,142 +34,23 @@ detect_anomalies <- function(
   verbose = FALSE,
   tso_params = list()
 ) {
-  ts_prep <- list()
-  for (code in codes) {
-    ts_data <- tryCatch(
-      extract_ts(
-        import_data,
-        code = code,
-        date_col = date_col,
-        quantity = quantity,
-        fill_missing = 0,
-        freq = freq
-      ),
-      error = function(e) e
-    )
-
-    if (inherits(ts_data, "error")) {
-      message(paste("Skipping code", code, ":", ts_data))
-      next
-    } else {
-      ts_prep[[code]] <- ts_data
-    }
+  if (!inherits(data, "list")) {
+    stop("`data` must be a list.")
   }
 
-  rm(ts_data)
-  codes <- names(ts_prep)
-  p <- progressr::progressor(along = codes)
+  time_series_ids <- names(data)
 
-  process_ts <- function(ts_data, code) {
-    sparse_rate <- mean(ts_data[[quantity]] == 0, na.rm = T)
-
-    if (!is.na(sparse_rate) && sparse_rate > 0.4) {
-      message(paste(
-        "Skipping code",
-        code,
-        ":",
-        round(sparse_rate * 100, 2),
-        "% zeros"
-      ))
-      p(sprintf("Skipped %s", code))
-      return(NULL)
-    }
-
-    if (verbose) {
-      message(sprintf("Running selected_model for %s", code))
-    }
-
-    selected_model <- tryCatch(
-      select_best_model(
-        data = ts_data,
-        response_col = quantity,
-        date_col = date_col,
-        metric = model_selection_metric,
-        break_detection = TRUE
-      ),
-      error = function(e) e
-    )
-
-    if (inherits(selected_model, "error")) {
-      message(paste("Skipping code", code, ":", selected_model))
-      p(sprintf("Skipped %s", code))
-      return(NULL)
-    }
-
-    if (verbose) {
-      message(sprintf("Running detect_anomaly for %s", code))
-    }
-
-    ts_data <- selected_model$data
-    break_entry <- selected_model$break_entry
-    xreg_all <- model.matrix(selected_model$formula, data = ts_data)
-
-    #for ~ -1 models
-    if (ncol(xreg_all) == 0) {
-      xreg_all <- NULL
-    }
-
-    outliers <- detect_outliers(
-      data = ts_data,
-      quantity = "NET_MASS",
-      scale_ts = scale_ts,
-      xreg = xreg_all,
-      tso_params = tso_params
-    )
-
-    ts_data <- outliers$data
-
-    if (!is.null(outliers$outliers) && nrow(outliers$outliers) > 0) {
-      #store tso outliers data produced
-      new_outliers <- as.data.table(outliers$outliers)
-      new_outliers[, code := code]
-      new_outliers[,
-        model_formula := paste(deparse(selected_model$formula), collapse = " ")
-      ]
-
-      new_outliers[, time := ts_data$DATE_START[ind]]
-      new_outliers[, anomaly_type := "Outlier"]
-
-      outliers_entry <- new_outliers
-    } else {
-      outliers_entry <- data.table()
-    }
-
-    #add breaks table
-    if (!is.null(break_entry) && nrow(break_entry) > 0) {
-      break_entry[, code := code]
-      break_entry[,
-        model_formula := paste(deparse(selected_model$formula), collapse = " ")
-      ]
-      break_entry[, anomaly_type := "Break"]
-
-      outliers_entry <- rbindlist(
-        list(outliers_entry, break_entry),
-        fill = TRUE
-      )
-
-      setorder(outliers_entry, time)
-    } else {
-      break_entry <- data.table()
-    }
-
-    #no break no outlier option
-    if (nrow(outliers_entry) == 0) {
-      outliers_entry <- data.table(
-        code = code,
-        model_formula = paste(deparse(selected_model$formula), collapse = " "),
-        anomaly_type = "None"
-      )
-    }
-
-    p(sprintf("Completed code %s", code))
-    return(list(outliers = outliers_entry, list_of_ts = ts_data, code = code))
-  }
+  p <- progressr::progressor(along = time_series_ids)
 
   results <- future.apply::future_mapply(
-    process_ts,
+    .detect_anomalies_single_ts,
     ts_prep,
-    codes,
+    time_series_ids,
+    MoreArgs = list(
+      response_col = response_col,
+      date_col = date_col,
+      scale_ts = scale_ts
+    ),
     SIMPLIFY = FALSE,
     future.globals = list(),
     future.packages = c("bulktrends")
@@ -179,9 +59,140 @@ detect_anomalies <- function(
   results <- Filter(Negate(is.null), results)
   all_outliers <- lapply(results, `[[`, "outliers")
   list_of_ts <- lapply(results, `[[`, "list_of_ts")
-  names(list_of_ts) <- lapply(results, `[[`, "code")
+  names(list_of_ts) <- lapply(results, `[[`, "id")
   return(list(
     outliers = rbindlist(all_outliers, fill = TRUE),
     list_of_ts = list_of_ts
   ))
+}
+
+#' Detect anomalies in a single time series (Internal)
+#' @note This needs to return a list of time series with original tsibble attributes. See suggested pattern in comments...
+#'
+.detect_anomalies_single_ts <- function(
+  ts_data,
+  id,
+  response_col,
+  date_col,
+  scale_ts
+) {
+
+  if ( inherits(ts_data,"tsibble") ) {
+    # Store attributes & convert to data.table...
+    #
+    # .tsibble_attributes <- attr(ts_data)
+    # ts_data <- data.table::as.data.table(ts_data)
+  }
+
+  sparse_rate <- mean(ts_data[[response_col]] == 0, na.rm = T)
+
+  if (!is.na(sparse_rate) && sparse_rate > 0.4) {
+    message(paste(
+      "Skipping time series",
+      id,
+      ":",
+      round(sparse_rate * 100, 2),
+      "% zeros"
+    ))
+    p(sprintf("Skipped %s", id))
+    return(NULL)
+  }
+
+  if (verbose) {
+    message(sprintf("Running selected_model for %s", id))
+  }
+
+  selected_model <- tryCatch(
+    select_best_model(
+      data = ts_data,
+      response_col = response_col,
+      date_col = date_col,
+      metric = model_selection_metric,
+      break_detection = TRUE
+    ),
+    error = function(e) e
+  )
+
+  if (inherits(selected_model, "error")) {
+    message("Skipping time series", id, ":", selected_model)
+    p(sprintf("Skipped %s", id))
+    return(NULL)
+  }
+
+  if (verbose) {
+    message(sprintf("Running detect_anomaly for %s", id))
+  }
+
+  ts_data <- selected_model$data
+  break_entry <- selected_model$break_entry
+  xreg_all <- model.matrix(selected_model$formula, data = ts_data)
+
+  #for ~ -1 models
+  if (ncol(xreg_all) == 0) {
+    xreg_all <- NULL
+  }
+
+  outliers <- detect_outliers(
+    data = ts_data,
+    quantity = response_col, ### Change quantity to response_col!!!
+    scale_ts = scale_ts,
+    xreg = xreg_all,
+    tso_params = tso_params
+  )
+
+  ts_data <- outliers$data
+
+  if (!is.null(outliers$outliers) && nrow(outliers$outliers) > 0) {
+    #store tso outliers data produced
+    new_outliers <- as.data.table(outliers$outliers)
+    new_outliers[, id := id]
+    new_outliers[,
+      model_formula := paste(deparse(selected_model$formula), collapse = " ")
+    ]
+
+    new_outliers[, time := ts_data$DATE_START[ind]]
+    new_outliers[, anomaly_type := "Outlier"]
+
+    outliers_entry <- new_outliers
+  } else {
+    outliers_entry <- data.table()
+  }
+
+  #add breaks table
+  if (!is.null(break_entry) && nrow(break_entry) > 0) {
+    break_entry[, id := id]
+    break_entry[,
+      model_formula := paste(deparse(selected_model$formula), collapse = " ")
+    ]
+    break_entry[, anomaly_type := "Break"]
+
+    outliers_entry <- rbindlist(
+      list(outliers_entry, break_entry),
+      fill = TRUE
+    )
+
+    setorder(outliers_entry, time)
+  } else {
+    break_entry <- data.table()
+  }
+
+  #no break no outlier option
+  if (nrow(outliers_entry) == 0) {
+    outliers_entry <- data.table(
+      id = id,
+      model_formula = paste(deparse(selected_model$formula), collapse = " "),
+      anomaly_type = "None"
+    )
+  }
+
+  if ( inherits(ts_data,"tsibble") ) {
+    # Covert back to tsibble and assign attributes...
+    #
+    # ts_data <- fable::as.tsibble(ts_data)
+    # attr(ts_data) <- .tsibble_attributes
+
+  }
+
+  p(sprintf("Completed time series %s", id))
+  return(list(outliers = outliers_entry, list_of_ts = ts_data, id = id))
 }

--- a/R/detect_breaks.R
+++ b/R/detect_breaks.R
@@ -26,8 +26,9 @@ detect_breaks <- function(data, date_col = "DATE_START", formula) {
   if (length(breaks) > 0 && !all(is.na(breaks))) {
     time <- data[[date_col]][breaks]
     output <- data.table(type = "SB", ind = breaks, time = time)
-    segments <- as.matrix(strucchangeRcpp::breakfactor(bp))
+    segments <- as.data.table(as.matrix(strucchangeRcpp::breakfactor(bp)))
     colnames(segments) <- paste0("segments")
+    segments[, segments := as.factor(segments)]
     return(list(break_entry = output, segments = segments))
   } else {
     return(NULL)

--- a/R/utils.R
+++ b/R/utils.R
@@ -292,3 +292,38 @@ open_userguide <- function(path = NULL) {
     stop("Couldn't find UserGuide.html")
   }
 }
+
+
+#' prepare data into list of time series
+prepare_ts_data <- function(
+  data,
+  codes,
+  response_col = "NET_MASS",
+  date_col = "DATE_START",
+  freq = NULL,
+  fill_missing = 0
+) {
+  ts_prep <- list()
+
+  for (code in codes) {
+    ts_data <- tryCatch(
+      extract_ts(
+        import_data = data,
+        code = code,
+        date_col = date_col,
+        quantity = response_col,
+        fill_missing = fill_missing,
+        freq = freq
+      ),
+      error = function(e) NULL
+    )
+
+    if (is.null(ts_data)) {
+      next
+    }
+
+    ts_prep[[code]] <- ts_data
+  }
+
+  return(ts_prep)
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -295,16 +295,18 @@ open_userguide <- function(path = NULL) {
 
 
 #' prepare data into list of time series
-prepare_ts_data <- function(
+prep_ts_data <- function(
   data,
   codes,
   response_col = "NET_MASS",
   date_col = "DATE_START",
   freq = NULL,
   fill_missing = 0
+  #format ?
 ) {
   ts_prep <- list()
 
+  # if(format=="data_table"){
   for (code in codes) {
     ts_data <- tryCatch(
       extract_ts(
@@ -324,6 +326,12 @@ prepare_ts_data <- function(
 
     ts_prep[[code]] <- ts_data
   }
+  #}
+
+  #  else if(format=="tsibble"){
+  #    tsibble_data <- generate_tstibble(data=imports, hierarchy = c("HS2", "HS4"), groups= "category")
+  #split tsibble into ts_prep per hierarchy id
+  #  }
 
   return(ts_prep)
 }


### PR DESCRIPTION
# Refactor of `detect_anomalies`

Main aims:
1. Remove data preparation steps from `detect_anomalies`. The functions should only perform its main task, not wrap data wrangling.
2. Generalise to accept arbitrary lists/groups of time series, not just specific commodity code aggregation
3. Accept data in `tsibble` format, which will be used for forecasting. `tsibble` attributes (i.e. time series hierarchy and grouping) should be retained.